### PR TITLE
Fix incorrect script path in build-local-docker-image.sh

### DIFF
--- a/build-local-docker-image.sh
+++ b/build-local-docker-image.sh
@@ -45,7 +45,7 @@ function copy_gui_artifacts() {
 function package_nocodb() {
     # build nocodb ( pack nocodb-sdk and nc-gui )
     cd ${SCRIPT_DIR}/packages/nocodb
-    EE=true ${SCRIPT_DIR}/node_modules/@rspack/cli/bin --config ${SCRIPT_DIR}/packages/nocodb/rspack.config.js || ERROR="package_nocodb failed"
+    EE=true ${SCRIPT_DIR}/node_modules/@rspack/cli/bin/rspack.js --config ${SCRIPT_DIR}/packages/nocodb/rspack.config.js || ERROR="package_nocodb failed"
 }
 
 function build_image() {


### PR DESCRIPTION
 This PR fixes an issue in `build-local-docker-image.sh` at line 48, where the script attempted to execute a directory instead of a file. The incorrect command was:  
```sh
EE=true ${SCRIPT_DIR}/node_modules/@rspack/cli/bin
```
This caused the following error during the build process:  
```
./build-local-docker-image.sh: line 48: ./node_modules/@rspack/cli/bin: Is a directory
```
The error was also reflected in `build-local-docker-image.log` as:  
```
Info: Build nocodb, package nocodb-sdk and nc-gui
ERROR: package_nocodb failed
```
The corrected command now explicitly points to the executable file within the directory. This change ensures successful execution of the build script.  

Let me know if any additional changes or explanations are required.  